### PR TITLE
(#10867) Add client region lookup fact

### DIFF
--- a/ext/external_node
+++ b/ext/external_node
@@ -18,7 +18,7 @@ if facts
   # the stackname and resource id facts are currently laid
   # down by the cloud formation script
   if facts.values['cfn_stack_name'] and facts.values['cfn_resource_id'] and File.exists?(credential_file)
-    command = "/opt/aws/bin/cfn-get-metadata --region us-east-1 -s #{facts.values['cfn_stack_name']} -r #{facts.values['cfn_resource_id']} -f #{credential_file} --key Puppet"
+    command = "/opt/aws/bin/cfn-get-metadata --region #{facts.values['cfn_region']} -s #{facts.values['cfn_stack_name']} -r #{facts.values['cfn_resource_id']} -f #{credential_file} --key Puppet"
     classification_meta_data = `#{command}`.downcase
     unless classification_meta_data == ''
       puts PSON.parse(classification_meta_data).to_yaml

--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -175,7 +175,8 @@
               "/etc/puppetlabs/facter/facts.d/cloudformation.txt": {
                 "content" : { "Fn::Join" : ["", [
                   "cfn_stack_name=",{ "Ref": "AWS::StackName" }, "\n",
-                  "cfn_resource_id=<%= agent_name %>"
+                  "cfn_resource_id=<%= agent_name %>", "\n",
+                  "cfn_region=", { "Ref": "AWS::Region" }
                 ]] }
               }
             }


### PR DESCRIPTION
The lookup of which region by the ENC was hard coded
to us-east-1.

This commit adds a fact called cfn_region so
that the ENC can dynamically lookup the region for
a node.

It also updates the ENC to use the cfn_region fact
