### PR TITLE
(#10843) add support for ENC non param classes

### DIFF
--- a/README
+++ b/README
@@ -62,12 +62,22 @@ them.
 
 The structure of the hash is described below:
 
+parameterized classes:
+
 puppet_agents:
   resource_id:
-    class_name1:
-      class_param1
-    class_name2:
-      class_param2
+    classes:
+      class_name1:
+        class_param1: value
+
+non_parameterized classes
+
+puppet_agents:
+  resource_id:
+    classes:
+      - class_name1
+    parameters:
+      class_param1: value
 
 There are a few existing examples in teh config directory:
 

--- a/config/ntp_nodes.config
+++ b/config/ntp_nodes.config
@@ -3,6 +3,7 @@ install_modules:
   - puppetlabs-ntp
 puppet_agents:
   NtpNode:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org

--- a/config/ntp_nodes_8.config
+++ b/config/ntp_nodes_8.config
@@ -3,34 +3,42 @@ install_modules:
   - puppetlabs-ntp
 puppet_agents:
   NtpNode1:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode2:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode3:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode4:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode5:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode6:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode7:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org
   NtpNode8:
-    ntp:
-      servers:
-        0.north-america.pool.ntp.org
+    classes:
+      ntp:
+        servers:
+          0.north-america.pool.ntp.org

--- a/config/test.config
+++ b/config/test.config
@@ -1,0 +1,14 @@
+install_modules:
+  - bodepd-testmodule
+puppet_agents:
+  NonParamClassAgent:
+    classes:
+      - testmodule::non_param_class
+    parameters:
+      foo: non_param_foo
+      bar: non_param_bar
+  ParamClassAgent:
+    classes:
+      testmodule::param_class:
+        foo: param_foo
+        bar: param_bar

--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -159,7 +159,7 @@
             "\n" ]]}}
       }
     },
-<% puppet_agents.each do |agent_name, klasses| -%>
+<% puppet_agents.each do |agent_name, classify_data| classify_data ||= {} -%>
     "<%= agent_name %>": {
       "Type": "AWS::EC2::Instance",
       "DependsOn" : "PuppetMasterWaitCondition",
@@ -184,7 +184,8 @@
           }
         },
         "Puppet" : {
-          "Classes" : <%= (klasses || {}).to_pson %>
+          "Classes" : <%= (classify_data['classes'] || {}).to_pson %>,
+          "Parameters": <%= (classify_data['parameters'] || {}).to_pson %>
         }
       },
       "Properties": {


### PR DESCRIPTION
changes the structure of the config to look more
like ENC yaml.

resource_id => classes,parameters

Updates template to support this new config format.

Add an example config that uses my test module

update README to show changed config syntax
