### PR TITLE
(#10983) Only capture outputs for first 8 agents

### DIFF
--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -250,7 +250,7 @@
     "PuppetMasterPublicDnsName" : {
       "Value" : { "Fn::GetAtt" : [ "PuppetMasterInstance", "PublicDnsName" ] }
     },
-<% puppet_agents.keys.each do |agent_name| -%>
+<% puppet_agents.keys[0..8].each do |agent_name| -%>
   "<%= agent_name %>PublicDnsName" : {
       "Value" : { "Fn::GetAtt" : [ "<%= agent_name %>", "PublicDnsName" ] }
     },


### PR DESCRIPTION
There is a cfn limit on max 10 outputs. The code
was previously created an output per agent, imposing a
limit on the total number of agents supported to be 8.

This patch only captures output for the first 8 agents.
