### PR TITLE
(#10983) fixes off by one error on output generation

### DIFF
--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -250,7 +250,7 @@
     "PuppetMasterPublicDnsName" : {
       "Value" : { "Fn::GetAtt" : [ "PuppetMasterInstance", "PublicDnsName" ] }
     },
-<% puppet_agents.keys[0..8].each do |agent_name| -%>
+<% puppet_agents.keys[0..7].each do |agent_name| -%>
   "<%= agent_name %>PublicDnsName" : {
       "Value" : { "Fn::GetAtt" : [ "<%= agent_name %>", "PublicDnsName" ] }
     },


### PR DESCRIPTION
The previous patch to restrict the outputs generated
to just the first 8 agents had an off by one error.

This commit resolves that issue.
