### PR TITLE
(#10996) add group example config file

### DIFF
--- a/config/group-example.config
+++ b/config/group-example.config
@@ -1,0 +1,35 @@
+#
+# This example confile file illustrates how to use
+# groups.
+#
+# first list what modules need to be installed on the master
+install_modules:
+  - bodepd-testmodule
+# then list the groups that need to exist in the dashboard
+dashboard_groups:
+  # parent groups need to be declared before their children
+  parent_group:
+    # groups can contain a list of classes
+    classes: testmodule::non_param_class
+    parameters:
+      foo: default
+  group_one:
+    # groups can specify parent groups
+    parent_groups:
+     - parent_group
+    # groups can include children
+    parameters:
+      bar: bar1
+  group_two:
+    parent_groups:
+     - parent_group
+    parameters:
+      foo: foo2
+      bar: bar2
+# list of puppet agents that will be created
+puppet_agents:
+  Agent1:
+    # agents are being assigned groups
+    groups: group_one
+  Agent2:
+    groups: group_two


### PR DESCRIPTION
This commit adds an example config file that
shows how to specify groups in the dashboard.
