### PR TITLE
(#10994) Add support for creating security groups

### DIFF
--- a/config/test.config
+++ b/config/test.config
@@ -7,8 +7,13 @@ puppet_agents:
     parameters:
       foo: non_param_foo
       bar: non_param_bar
+    ports:
+      - 80
   ParamClassAgent:
     classes:
       testmodule::param_class:
         foo: param_foo
         bar: param_bar
+    ports:
+      - 80
+      - 8080

--- a/lib/puppet/cloudformation.rb
+++ b/lib/puppet/cloudformation.rb
@@ -35,7 +35,8 @@ module Puppet::CloudFormation
       agent_rules = {
         'classes'    => [Array, Hash, String],
         'parameters' => [Hash],
-        'groups'     => [Array, String]
+        'groups'     => [Array, String],
+        'ports'      => [Array]
       }
       if ! config || config == ''
         config = {}
@@ -66,6 +67,21 @@ module Puppet::CloudFormation
           end
         end
       end
+    end
+
+    # find all of the ports from the config
+    # and create security groups for them
+    # right now it assumes that all ports are tcp ports
+    def get_ports(config)
+      (config['puppet_agents'] || {}).collect do |agent_name, agent_values|
+        ports = agent_values['ports'] || []
+        if ports.is_a?(Array)
+          ports = ports
+        elsif ports.is_a?(Fixnum) or ports.is_a?(String)
+          ports = ports.to_s.to_a
+        end
+        ports
+      end.flatten.uniq
     end
   end
 end

--- a/lib/puppet/face/cloudformation.rb
+++ b/lib/puppet/face/cloudformation.rb
@@ -65,6 +65,7 @@ Puppet::Face.define(:cloudformation, '0.0.1') do
       # set the local vairables install_modules and puppet_agents from our config file
       config = YAML.load_file(options[:config])
       Puppet::CloudFormation.validate_config(config)
+      allowed_ports = Puppet::CloudFormation.get_ports(config)
       dashboard_groups = {}
       install_modules = []
       puppet_agents = {}

--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -75,6 +75,17 @@
         ]
       }
     },
+<% allowed_ports.each do |port| -%>
+    "Port<%= port %>": {
+      "Type" : "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription" : "Allows incoming tcp connections to port #{port}",
+        "SecurityGroupIngress" : [
+        { "IpProtocol" : "tcp", "FromPort": "<%= port %>", "ToPort": "<%= port %>", "CidrIp": "0.0.0.0/0" }
+        ]
+      }
+    },
+<% end %>
     "PuppetClientSecurityGroup" : {
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -203,7 +214,12 @@
                     { "Fn::FindInMap" : [ "AWSInstanceType2Arch", { "Ref" : "AgentInstanceType" }, "Arch" ] }
  ] },
         "KeyName": { "Ref": "KeyName" },
-        "SecurityGroups":  [ { "Ref" : "PuppetClientSecurityGroup" } ],
+        "SecurityGroups":  [
+<% (classify_data['ports'] || []).each do |port| -%>
+          { "Ref" : "Port<%= port %>" },
+<% end -%>
+          { "Ref" : "PuppetClientSecurityGroup" }
+        ],
         "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
             "#!/bin/bash\n",
             "/opt/aws/bin/cfn-init --region ", { "Ref" : "AWS::Region" },


### PR DESCRIPTION
This commit adds support for dynamically crreating
security groups. Ports can be specified as an array
per agent. A single security group is created for
each port.

Adds port examples to test config

Adds validation for ports to only accept an array

Add method to parse ports out of agents and return
a list.

Adds creation of security group and assignment of
security groups to agent to erb template.
