### PR TITLE
(#11018) Remove agent outputs

### DIFF
--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -266,11 +266,6 @@
     "PuppetMasterPublicDnsName" : {
       "Value" : { "Fn::GetAtt" : [ "PuppetMasterInstance", "PublicDnsName" ] }
     },
-<% puppet_agents.keys[0..7].each do |agent_name| -%>
-  "<%= agent_name %>PublicDnsName" : {
-      "Value" : { "Fn::GetAtt" : [ "<%= agent_name %>", "PublicDnsName" ] }
-    },
-<% end -%>
     "PuppetMasterPrivateDnsName" : {
       "Value" : { "Fn::GetAtt" : [ "PuppetMasterInstance", "PrivateDnsName" ] }
     }


### PR DESCRIPTION
B/c cloudformation is restricted to only 10 outputs
, it did not make sense to capture only the first
8 agents(and ignore the rest).

This commit only captures the master's outputs.
This should be sufficient b/c you can view all of
the agents through the master's dashboard.
