### PR TITLE
(#11033) fix lib path in bashrc template

### DIFF
--- a/templates/bashrc_cfn.erb
+++ b/templates/bashrc_cfn.erb
@@ -2,4 +2,4 @@ export AWS_CLOUDFORMATION_HOME=<%= base_dir %>/AWSCloudFormation-<%= cfn_version
 export PATH=$AWS_CLOUDFORMATION_HOME/bin:$PATH
 export AWS_CREDENTIAL_FILE=<%= aws_credential_file %>
 export JAVA_HOME=<%= java_home %>
-export RUBYLIB=<%= base_dir %>/site_lib:$RUBYLIB
+export RUBYLIB=<%= base_dir %>/lib:$RUBYLIB


### PR DESCRIPTION
This commit fixes the lib dir from site_lib to
lib so that the generated rc file is correct.

The libdir had accidentally been changed from
lib to site_lib.
