### PR TITLE
(#11189) Fix Agent payload arch lookup

### DIFF
--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -198,7 +198,7 @@
               "/root/": { "Fn::FindInMap" : [
                   "ArchToPayload",
                   { "Fn::FindInMap" :
-                    ["AWSInstanceType2Arch", { "Ref" : "MasterInstanceType" }, "Arch"] },
+                    ["AWSInstanceType2Arch", { "Ref" : "AgentInstanceType" }, "Arch"] },
                 "Payload"] }
             },
             "files": {
@@ -244,7 +244,7 @@
             { "Fn::FindInMap" : [
               "ArchToPayloadDir",
                { "Fn::FindInMap" :
-                    ["AWSInstanceType2Arch", { "Ref" : "MasterInstanceType" }, "Arch"] },
+                    ["AWSInstanceType2Arch", { "Ref" : "AgentInstanceType" }, "Arch"] },
                "PayloadDir"]
             },
             "/puppet-enterprise-installer -a /root/answers -D  >& /tmp/pe-install.txt",  "\n",


### PR DESCRIPTION
Previously, the agent was using the master's instance
type to map to the payload to use during
installation.

This was causing failures in the case where the
master and agent did not have the same architecture.

This patch fixes the agent to use the correct type.
