### PR TITLE
(#11244) Update to work with v0.0.1 of puppetlabs-dashboard

### DIFF
--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -125,7 +125,7 @@
                   { "Fn::FindInMap" :
                     ["AWSInstanceType2Arch", { "Ref" : "MasterInstanceType" }, "Arch"] },
                 "Payload"] },
-                "/etc/puppetlabs/puppet/modules/puppetlabs-dashboard/" : "https://github.com/bodepd/puppetlabs-dashboard/tarball/master"
+                "/etc/puppetlabs/puppet/modules/puppetlabs-dashboard/" : "https://github.com/puppetlabs/puppetlabs-dashboard/tarball/v0.0.1"
             },
             "files": {
               "/root/answers": {
@@ -180,7 +180,7 @@
             "echo '*' >> /etc/puppetlabs/puppet/autosign.conf", "\n",
             "mv /var/lib/cfn-init/data/external_node /etc/puppetlabs/puppet-dashboard/external_node", "\n",
             "chown -Rvf pe-puppet:pe-puppet /var/lib/cfn-init/data/cfn-credentials /etc/puppetlabs/puppet-dashboard/external_node /etc/puppetlabs/puppet/modules", "\n",
-            "export PATH=/usr/local/bin/:$PATH;export RUBYLIB=/etc/puppetlabs/puppet/modules/puppetlabs-dashboard/site_lib;/opt/puppet/bin/puppet dashboard add_module --modulepath /etc/puppetlabs/puppet/modules/ --enc-server localhost --enc-port 443 --enc-ssl --enc-auth-user cfn_user --enc-auth-passwd cfn_password --module-name=<%= install_modules.join(',') %>", "\n",
+            "export PATH=/usr/local/bin/:$PATH;export RUBYLIB=/etc/puppetlabs/puppet/modules/puppetlabs-dashboard/site_lib;/opt/puppet/bin/puppet dashboard add_module --modulepath /etc/puppetlabs/puppet/modules/ --enc-server localhost --enc-port 443 --enc-ssl --enc-auth-user cfn_user --enc-auth-passwd cfn_password --module-names=<%= install_modules.join(',') %>", "\n",
             "/var/lib/cfn-init/data/sync_group.rb\n",
             "echo 'node default { include pe_mcollective }' > /etc/puppetlabs/puppet/manifests/site.pp", "\n",
             "/opt/aws/bin/cfn-signal -e $? '", { "Ref" : "PuppetMasterWaitHandle" }, "'\n",


### PR DESCRIPTION
2 things have changed with the first released
version of puppetlabs-dashboard. module-name has
changed to module-names for the add_module action
and the code has moved to the puppetlabs account
on github.

This commit updates the cloudformation template
to use the released version of puppetlabs-dashboard.
