### PR TITLE
Use PE 2.0.1 instead of PE 2.0.0

### DIFF
--- a/lib/puppet/templates/pe.erb
+++ b/lib/puppet/templates/pe.erb
@@ -32,12 +32,12 @@
   },
   "Mappings" : {
     "ArchToPayload" : {
-      "32" : {"Payload" : "https://s3.amazonaws.com/pe-builds/released/2.0.0/puppet-enterprise-2.0.0-el-6-i386.tar.gz"},
-      "64" : {"Payload" : "https://s3.amazonaws.com/pe-builds/released/2.0.0/puppet-enterprise-2.0.0-el-6-x86_64.tar.gz"}
+      "32" : {"Payload" : "https://s3.amazonaws.com/pe-builds/released/2.0.1/puppet-enterprise-2.0.1-el-6-i386.tar.gz"},
+      "64" : {"Payload" : "https://s3.amazonaws.com/pe-builds/released/2.0.1/puppet-enterprise-2.0.1-el-6-x86_64.tar.gz"}
     },
     "ArchToPayloadDir" : {
-      "32" : {"PayloadDir" : "puppet-enterprise-2.0.0-el-6-i386"},
-      "64" : {"PayloadDir" : "puppet-enterprise-2.0.0-el-6-x86_64"}
+      "32" : {"PayloadDir" : "puppet-enterprise-2.0.1-el-6-i386"},
+      "64" : {"PayloadDir" : "puppet-enterprise-2.0.1-el-6-x86_64"}
     },
     "AWSInstanceType2Arch" : {
       "t1.micro"    : { "Arch" : "32" },


### PR DESCRIPTION
Puppet Enterprise 2.0.1 fixes many bugs found in PE 2.0.0 and should
be used by default for all stacks.
