### PR TITLE
Adjust pedemo.config for pe_demo module changes

### DIFF
--- a/config/pedemo.config
+++ b/config/pedemo.config
@@ -26,7 +26,7 @@ install_modules:
 dashboard_groups:
   pe_demo:
     classes:
-      - pe_demo::live_management
+      - pe_demo
 # Here's where the Puppet agents are defined. Note that the Puppet Master is
 # automatically defined for you.
 puppet_agents:
@@ -51,12 +51,4 @@ puppet_agents:
     classes:
       - pe_demo::motd
   Agent5:
-    groups: pe_demo
-  Agent6:
-    groups: pe_demo
-  Agent7:
-    groups: pe_demo
-  Agent8:
-    groups: pe_demo
-  Agent9:
     groups: pe_demo


### PR DESCRIPTION
The pe_demo module was adjusted to use the pe_demo class by default
and to revert the decision to randomize the home directories
because that behavior as implemented is sketchy at best.

This commit also reduces the number of nodes provisioned to 5 agents
as 9 agents takes just long enough to be unbearable.
